### PR TITLE
Fix #14 Avoid deprecation warning in Matplotlib 3.2: font_manager.createFontList()

### DIFF
--- a/japanize_matplotlib/japanize_matplotlib.py
+++ b/japanize_matplotlib/japanize_matplotlib.py
@@ -2,6 +2,7 @@ import os
 
 import matplotlib
 from matplotlib import font_manager
+from distutils.version import LooseVersion
 
 FONTS_DIR = 'fonts'
 FONT_NAME = "IPAexGothic"
@@ -12,8 +13,13 @@ def japanize():
     font_dir_path = get_font_path()
     font_dirs = [font_dir_path]
     font_files = font_manager.findSystemFonts(fontpaths=font_dirs)
-    font_list = font_manager.createFontList(font_files)
-    font_manager.fontManager.ttflist.extend(font_list)
+    is_support_createFontList = LooseVersion(matplotlib.__version__) < '3.2'
+    if is_support_createFontList:
+        font_list = font_manager.createFontList(font_files)
+        font_manager.fontManager.ttflist.extend(font_list)
+    else:
+        for fpath in font_files:
+            font_manager.fontManager.addfont(fpath)
     matplotlib.rc('font', family=FONT_NAME)
 
 


### PR DESCRIPTION
## 概要

matplotlibのバージョンが3.2以降の環境の場合、以下のようなWarningが出てしまっていました( #14 )

```
$ pip install japanize-matplotlib
$ python -c "from matplotlib import pyplot as plt; import japanize_matplotlib"
/Users/amedama/.virtualenvs/py37/lib/python3.7/site-packages/japanize_matplotlib/__init__.py:13: MatplotlibDeprecationWarning: 
The createFontList function was deprecated in Matplotlib 3.2 and will be removed two minor releases later. Use FontManager.addfont instead.
  font_list = font_manager.createFontList(font_files)
```

## 変更内容

具体的には以下の流れでfontの追加を行うようにしてみました。

- 利用されているmatplotlibのバージョンを確認
- 3.2より前のバージョンであれば、[`font_manager.createFontList()`](https://matplotlib.org/3.1.1/api/font_manager_api.html#matplotlib.font_manager.createFontList)を使って従来通りにfontの追加を行う
- 3.2以降のバージョンであれば、[`FontManager.addfont()`](https://matplotlib.org/3.2.1/api/font_manager_api.html#matplotlib.font_manager.FontManager.addfont)を使ってfontの追加を行う
