### PR TITLE
avoid deprecation warning for LooseVersion

### DIFF
--- a/japanize_matplotlib/japanize_matplotlib.py
+++ b/japanize_matplotlib/japanize_matplotlib.py
@@ -2,7 +2,7 @@ import os
 
 import matplotlib
 from matplotlib import font_manager
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 FONTS_DIR = 'fonts'
 FONT_NAME = "IPAexGothic"
@@ -13,7 +13,7 @@ def japanize():
     font_dir_path = get_font_path()
     font_dirs = [font_dir_path]
     font_files = font_manager.findSystemFonts(fontpaths=font_dirs)
-    is_support_createFontList = LooseVersion(matplotlib.__version__) < '3.2'
+    is_support_createFontList = Version(matplotlib.__version__) < Version('3.2')
     if is_support_createFontList:
         font_list = font_manager.createFontList(font_files)
         font_manager.fontManager.ttflist.extend(font_list)


### PR DESCRIPTION
The current version emits a warning
```
$ python -Wdefault demo.py 
.../japanize_matplotlib.py:16: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
  is_support_createFontList = LooseVersion(matplotlib.__version__) < '3.2'
.../site-packages/setuptools/_distutils/version.py:345: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
  other = LooseVersion(other)
```
so I have updated the code to use `packaging.version.Version` instead.